### PR TITLE
bugfixes + UI impovements

### DIFF
--- a/layouts/news/list.html
+++ b/layouts/news/list.html
@@ -1,0 +1,19 @@
+{{ define "main" }}
+<main class="main list" role="main">
+	{{- with .Title }}
+	<header class="main__header">
+		<h1>{{ . }}</h1>
+	</header>
+	{{- end }}
+	{{- with .Content }}
+	<div class="content main__content clearfix">
+		{{ . }}
+	</div>
+	{{- end }}
+	{{- range .Paginator.Pages }}
+        {{ .Date | time.Format ":date_short"}}<br/>
+		{{- .Render "summary" }}
+	{{- end }}
+</main>
+{{ partial "pagination.html" . }}
+{{ end }}

--- a/layouts/news/post.html
+++ b/layouts/news/post.html
@@ -4,7 +4,7 @@
 		{{ partial "post_thumbnail.html" (dict "class" "post" "page" .) }}
 		{{- partial "post_toc.html" . -}}
 		<div class="content post__content clearfix">
-			<h2>{{ .Title }}</h2>
+			<h1> <a href="/news">News</a> » {{ .Title }}</h1>
 			{{ .Params.date | time.Format ":date_short"}}<br/>
 			<b>{{ .Params.author }}</b></br>
             <hr>

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -201,24 +201,45 @@
 		color: #000;
 	}
 
+    /* [ddh] 
+     * The default heading size values are too big, in my opinion. So I
+     * adjusted each one to the next smallest size, with h4=h5=h6
+     * (theme default has h5=h6)
+     */
 	h1 {
+        /* 
 		font-size: 32px;
 		font-size: 2rem;
-	}
-
-	h2 {
+        */
 		font-size: 24px;
 		font-size: 1.5rem;
 	}
 
-	h3 {
+	h2 {
+        /*
+		font-size: 24px;
+		font-size: 1.5rem;
+        */
 		font-size: 20px;
 		font-size: 1.25rem;
 	}
 
-	h4 {
-		font-size: 18px;
+	h3 {
+        /*
+		font-size: 20px;
+		font-size: 1.25rem;
+        */
+        font-size: 18px;
 		font-size: 1.125rem;
+	}
+
+	h4 {
+		/*
+        font-size: 18px;
+		font-size: 1.125rem;
+        */
+		font-size: 16px;
+		font-size: 1rem;
 	}
 
 	h5 {
@@ -459,7 +480,7 @@
 
 	.logo__img {
 		max-height: 256px;
-		background-color: #ffffff;
+		background-color: rgba(255, 255, 255, 0.75);
 	}
 
 	.logo__text {
@@ -474,8 +495,8 @@
 	}
 
 	.logo--mixed .logo__img {
-		max-width: 128px;
-		max-height: 128px;
+		max-width: 142px;
+		max-height: 142px;
 	}
 
 	.logo--mixed .logo__text {


### PR DESCRIPTION
bugs:
- icapslogo now aligns with title textbox (I made it slighty bigger)
- moved layouts for news pages (they now only apply to content in the news section)

improvements:
- reduced the opacity to the icaps logo; I think it looks better, slightly see-through
- reduced the sizes of the default h1/h2/h3/h4 elements. each one is now the size of the previous one (i.e., h1=h2, h2=h3 etc). I think this is better, as h1 was really large before and especially ugly when the page contains a smaller amount of text