### PR TITLE
Fix layout for nested menus

### DIFF
--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1,5 +1,16 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
 
+html {
+	--icaps-2025-header-accent-color: #f5821f;
+	--icaps-2025-header-action-color: #b6c2cf;
+	--icaps-2025-header-text-color: #b6c2cf;
+	--icaps-2025-header-bg-color: #1d2125;
+	--icaps-2025-header-divider: #333c43;
+	--icaps-2025-header-bg-color-active: #282d33;
+	/* Change this to 'none' to hide title */
+	--icaps-2025-display-title: inline-block;
+}
+
 *,
 *::before,
 *::after {
@@ -536,7 +547,7 @@ button:not(:-moz-focusring):focus > .menu__btn-title {
 }
 
 .menu__item:hover {
-	background: #f5821f;
+	background: var(--icaps-2025-header-bg-color-active);
 }
 
 .menu__item:first-child {
@@ -1286,18 +1297,19 @@ textarea {
 	transition-duration: 300ms;
 }
 
+nav.menu .drop-icon {
+	transform: rotate(0deg);
+	opacity: 0.8;
+	font-weight: 500;
+	margin-left: 5px;
+	line-height: 1.2;
+	font-size: 1.2em;
+}
+
 @media screen and (max-width: 767px) {
 	.header__container {
 		display: flex;
 		flex-direction: column-reverse;
-		--icaps-2025-header-accent-color: #f5821f;
-		--icaps-2025-header-action-color: #b6c2cf;
-		--icaps-2025-header-text-color: #b6c2cf;
-		--icaps-2025-header-bg-color: #1d2125;
-		--icaps-2025-header-divider: #333c43;
-		--icaps-2025-header-bg-color-active: #282d33;
-		/* Change this to 'none' to hide title */
-		--icaps-2025-display-title: inline-block;
 	}
 
 	/* ─── Appbar ─────────────────────────────────────────────────────── */
@@ -1367,13 +1379,8 @@ textarea {
 		color: var(--icaps-2025-header-accent-color) !important;
 	}
 
-	nav.menu .drop-icon {
-		transform: rotate(-90deg);
-		opacity: 0.8;
-	}
-
 	nav.menu input:checked + .drop-icon {
-		transform: rotate(0deg);
+		transform: rotate(90deg);
 	}
 
 	/* ─── Logo ───────────────────────────────────────────────────────── */
@@ -1678,19 +1685,34 @@ highlightColor .menu__list--transition {
 		opacity: 1;
 		display: grid;
 		margin-left: -20px;
+		margin-right: -20px;
 		margin-top: 10px;
 	}
 
-	.menu__list .menu__item .submenu__list {
+	.drop-icon {
+		transform: rotate(90deg);
+	}
+
+	.menu__list > .menu__item > .menu__link > .submenu__list {
+		/* Ballpark header height */
+		max-height: max(120px, calc(100vh - 460px));
+		overflow-y: auto;
+	}
+
+	.submenu__list > ul > li > label.menu__link {
+		padding-bottom: 0;
+		color: #ffffff88;
+	}
+
+	.menu__list > .menu__item > label > .submenu__list {
 		background: #2a2a2a;
 		visibility: hidden;
 		opacity: 0;
 		position: absolute;
 		max-width: 15rem;
 		transition: all 0.5s ease;
-
+		width: 100%;
 		border-top: 5px solid #f5821f;
-
 		display: none;
 	}
 	.menu {
@@ -1714,8 +1736,8 @@ highlightColor .menu__list--transition {
 		transform: none;
 	}
 
-	.menu__item {
-		border-left: 1px solid rgba(255, 255, 255, 0.1);
+	.menu__item .menu__link:hover {
+		background: #373737;
 	}
 }
 
@@ -1746,9 +1768,35 @@ highlightColor .menu__list--transition {
 	.menu__item.menu__dropdown input[type="checkbox"] ~ .submenu__list > * {
 		overflow-y: hidden;
 	}
+<<<<<<< Updated upstream
 	.menu__item.menu__dropdown input[type="checkbox"] ~ .submenu__list > * > * {
 		padding-left: 20px;
 	}
+=======
+	.menu__item.menu__dropdown > label {
+		cursor: pointer;
+	}
+}
+
+.menu__item.menu__dropdown
+	input[type="checkbox"]
+	~ .submenu__list
+	> *
+	> *
+	.menu__text {
+	display: inline-block;
+	padding-left: 20px;
+}
+.menu__item.menu__dropdown
+	input[type="checkbox"]
+	~ .submenu__list
+	> *
+	> *
+	> *
+	> *
+	.menu__text {
+	padding-left: 40px;
+>>>>>>> Stashed changes
 }
 
 @media screen and (max-width: 620px) {
@@ -1770,5 +1818,60 @@ highlightColor .menu__list--transition {
 		display: block;
 		position: relative;
 		max-width: 100%;
+	}
+}
+
+@media (pointer: fine) {
+	html {
+		--scrollbar-size: 12px;
+	}
+	* {
+		scrollbar-color: inherit transparent;
+		scrollbar-width: var(--scrollbar-size);
+		transition: --scrollbar-size 300ms linear;
+	}
+	*::-webkit-scrollbar {
+		width: var(--scrollbar-size);
+		height: 14px;
+		background-color: transparent;
+	}
+	.MuiPaper-root:hover {
+		/* --scrollbar-size: 8px; */
+	}
+	*::-webkit-scrollbar-track {
+		background: inherit;
+	}
+	*::-webkit-scrollbar-thumb {
+		background-color: color-mix(in srgb, currentColor 30%, transparent);
+		opacity: 0.8;
+		height: 14px;
+		min-height: 64px;
+		width: var(--scrollbar-size);
+		padding: 2px;
+		border: 2px solid transparent;
+		border-left: 4px solid transparent;
+		background-clip: padding-box;
+	}
+	*::-webkit-scrollbar-thumb:hover {
+		/* border-left: 0px solid transparent; */
+		background-color: color-mix(in srgb, currentColor 50%, transparent);
+	}
+	*::-webkit-scrollbar-thumb:active {
+		/* border-left: 0px solid transparent; */
+		background-color: color-mix(in srgb, currentColor 60%, transparent);
+	}
+	*::-webkit-scrollbar-thumb:horizontal {
+		border-left: 0;
+		width: 14px;
+		min-width: 64px;
+		width: var(--scrollbar-size);
+		height: 2px;
+		border-top: 6px solid transparent;
+	}
+	*::-webkit-scrollbar-thumb:horizontal:hover {
+		/* border-top: 0px solid transparent; */
+	}
+	*::-webkit-scrollbar-thumb:horizontal:active {
+		/* border-top: 0px solid transparent; */
 	}
 }

--- a/themes/mainroad/layouts/partials/menu.html
+++ b/themes/mainroad/layouts/partials/menu.html
@@ -14,7 +14,7 @@
         <span class="menu__text">
           {{ .Name }}</span>
         <input type="checkbox" id="{{ .Name }}">
-        <span class="drop-icon">▾</span>
+        <span class="drop-icon">›</span>
         {{ .Post }}
         </a>
         <ul class="submenu__list">
@@ -27,10 +27,11 @@
                 <span class="menu__text">
                   {{ .Name }}</span>
                 <input type="checkbox" id="{{ .Name }}">
-                <span class="drop-icon">▾</span>
+                <span class="drop-icon">›</span>
                 {{ .Post }}
                 </a>
                 <ul class="submenu__list">
+          <ul class="'submenu__listwrapper">
                   {{ range .Children }}
                   <li class="menu__item{{ if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} menu__item--active{{ end }}">
                     <a class="menu__link" href="{{ .URL }}">
@@ -40,7 +41,7 @@
                       {{ .Post }}
                     </a>
                   </li>
-                  {{ end }}
+                  {{ end }}</ul>
                 </ul>
             </li>
             {{- else }}


### PR DESCRIPTION
This commit adds CSS fixes for nested and oversized menus, particularly in the Program tab. In the previous version, the Workshops items are inaccessible in the desktop layout, and are bugged on mobile. These are fixed. Additionally, the dropdown menus in desktop mode are now height-constrained.

### Previous

#### Desktop

<img width="2360" height="1640" alt="icaps25 icaps-conference org_code_of_conduct_(iPad Air)" src="https://github.com/user-attachments/assets/caae0151-7747-4044-a68e-9e8f1a9abe28" />

#### Mobile

<img width="750" height="1334" alt="icaps25 icaps-conference org_organisation_conditions_for_acceptance_(iPhone SE)" src="https://github.com/user-attachments/assets/a05ee047-95c7-4600-ba9d-10e80080fbbf" />



### Fixed

#### Desktop

<img width="2360" height="1640" alt="localhost_1313_program_overview_(iPad Air)" src="https://github.com/user-attachments/assets/1d1204d6-18f9-4db6-8296-5a1449d40592" />

#### Mobile

<img width="750" height="1334" alt="localhost_1313_program_workshops_haxp_(iPhone SE)" src="https://github.com/user-attachments/assets/587b7e7c-ad21-4773-8073-e2920cf0fcd7" />
